### PR TITLE
scaffold core modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # GobLean
+
+Local-first telemetry specification framework.
+
+This repository currently provides the initial scaffolding:
+
+- Python package structure for ingesting HAR logs, normalizing events,
+  fingerprinting platform/SDK versions, and running deterministic validators.
+- `pyproject.toml` with core open-source dependencies.
+- Minimal CLI that counts HAR files in a folder.
+- Basic unit test to ensure the package imports.
+
+Future work will implement the detailed pipeline described in `AGENTS.MD`.

--- a/goblean/__init__.py
+++ b/goblean/__init__.py
@@ -1,0 +1,16 @@
+"""GobLean: Local telemetry spec framework.
+
+This package provides modules for ingesting HAR logs,
+normalizing telemetry, inferring platform/SDK versions,
+and validating events against evolving specs.
+"""
+
+from . import ingest, normalize, fingerprint, validator, dictionary
+
+__all__ = [
+    "ingest",
+    "normalize",
+    "fingerprint",
+    "validator",
+    "dictionary",
+]

--- a/goblean/cli.py
+++ b/goblean/cli.py
@@ -1,0 +1,20 @@
+"""Command line interface for GobLean."""
+from __future__ import annotations
+import argparse
+from pathlib import Path
+from .ingest import ingest_folder
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Ingest HAR logs")
+    parser.add_argument("path", type=Path, help="Folder of .har files")
+    args = parser.parse_args()
+
+    count = 0
+    for _ in ingest_folder(args.path):
+        count += 1
+    print(f"Ingested {count} HAR files")
+
+
+if __name__ == "__main__":
+    main()

--- a/goblean/dictionary/__init__.py
+++ b/goblean/dictionary/__init__.py
@@ -1,0 +1,13 @@
+"""Dictionary of telemetry parameters."""
+
+from collections import defaultdict
+from typing import Dict, Any
+
+
+def new_dictionary() -> Dict[str, Any]:
+    """Return an empty dictionary structure.
+
+    Real implementations will track types, ranges and stability for
+    each parameter.
+    """
+    return defaultdict(dict)

--- a/goblean/fingerprint/__init__.py
+++ b/goblean/fingerprint/__init__.py
@@ -1,0 +1,5 @@
+"""Platform and SDK version inference."""
+
+from .platform_version import fingerprint
+
+__all__ = ["fingerprint"]

--- a/goblean/fingerprint/platform_version.py
+++ b/goblean/fingerprint/platform_version.py
@@ -1,0 +1,15 @@
+"""Fingerprint platforms and SDK versions from telemetry."""
+from __future__ import annotations
+from typing import Dict, Any, Tuple
+
+
+def fingerprint(event: Dict[str, Any]) -> Tuple[str, str, Tuple[int, ...]]:
+    """Infer `(platform, sdk, version)` from a normalized event.
+
+    Returns
+    -------
+    platform, sdk, version
+        The platform name, SDK identifier, and semantic version tuple.
+    """
+    # TODO: use host/path/headers/param shapes
+    return "unknown", "unknown", ()

--- a/goblean/ingest/__init__.py
+++ b/goblean/ingest/__init__.py
@@ -1,0 +1,5 @@
+"""HAR ingestion utilities."""
+
+from .har_ingest import ingest_folder
+
+__all__ = ["ingest_folder"]

--- a/goblean/ingest/har_ingest.py
+++ b/goblean/ingest/har_ingest.py
@@ -1,0 +1,20 @@
+"""Functions for reading HAR files from disk.
+
+These stubs will evolve to parse thousands of HAR logs using
+haralyzer and custom parsers.
+"""
+from __future__ import annotations
+from pathlib import Path
+from typing import Iterable
+
+
+def ingest_folder(folder: Path) -> Iterable[Path]:
+    """Yield HAR file paths in *folder*.
+
+    Parameters
+    ----------
+    folder:
+        Directory containing `.har` files.
+    """
+    for path in folder.glob("*.har"):
+        yield path

--- a/goblean/normalize/__init__.py
+++ b/goblean/normalize/__init__.py
@@ -1,0 +1,5 @@
+"""Telemetry normalization utilities."""
+
+from .envelope import canonical_envelope
+
+__all__ = ["canonical_envelope"]

--- a/goblean/normalize/envelope.py
+++ b/goblean/normalize/envelope.py
@@ -1,0 +1,16 @@
+"""Canonical event envelope helpers.
+
+Functions here convert raw platform telemetry into a shared
+schema that downstream modules can operate on.
+"""
+from __future__ import annotations
+from typing import Any, Dict
+
+
+def canonical_envelope(raw_event: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a minimal canonical representation of *raw_event*.
+
+    This placeholder simply echoes the input; normalization logic
+    will map platform-specific fields into a shared schema.
+    """
+    return dict(raw_event)

--- a/goblean/validator/__init__.py
+++ b/goblean/validator/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic validators (FSM + invariants)."""
+
+from .fsm import evaluate
+
+__all__ = ["evaluate"]

--- a/goblean/validator/fsm.py
+++ b/goblean/validator/fsm.py
@@ -1,0 +1,20 @@
+"""Finite state machine based validation."""
+from __future__ import annotations
+from typing import Iterable, Any
+
+
+class ValidationResult:
+    """Result of a validation step."""
+
+    def __init__(self, status: str, reason: str | None = None):
+        self.status = status
+        self.reason = reason
+
+
+def evaluate(events: Iterable[Any]) -> ValidationResult:
+    """Run placeholder validator over *events*.
+
+    In the future this will implement a finite state machine and
+    invariant checks. For now it always abstains.
+    """
+    return ValidationResult("ABSTAIN")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "goblean"
+version = "0.1.0"
+description = "Local telemetry spec framework"
+authors = [{name = "GobLean"}]
+dependencies = [
+  "fastapi",
+  "polars",
+  "pydantic",
+  "duckdb",
+  "scikit-learn",
+  "umap-learn",
+  "hdbscan",
+  "tslearn",
+  "semver",
+  "haralyzer",
+]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,12 @@
+"""Sanity tests for package imports."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import goblean
+
+
+def test_import() -> None:
+    assert hasattr(goblean, "ingest")


### PR DESCRIPTION
## Summary
- add initial Python package for HAR ingestion, normalization, fingerprinting, and validation
- introduce CLI stub and dependency metadata
- include basic import test and gitignore
- remove stray compiled bytecode so repo contains only source files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb83c3ac388323959c358bbbd17d4c