### PR TITLE
Add heuristic platform fingerprinting

### DIFF
--- a/goblean/fingerprint/platform_version.py
+++ b/goblean/fingerprint/platform_version.py
@@ -1,15 +1,49 @@
 """Fingerprint platforms and SDK versions from telemetry."""
 from __future__ import annotations
+import re
 from typing import Dict, Any, Tuple
 
 
-def fingerprint(event: Dict[str, Any]) -> Tuple[str, str, Tuple[int, ...]]:
-    """Infer `(platform, sdk, version)` from a normalized event.
+def _parse_version(text: str) -> Tuple[int, ...]:
+    """Return a semantic-version tuple from *text*.
 
-    Returns
-    -------
-    platform, sdk, version
-        The platform name, SDK identifier, and semantic version tuple.
+    Non-numeric components are ignored so ``"3.6.0"`` becomes ``(3, 6, 0)``
+    and ``"1.2beta"`` becomes ``(1, 2)``.
     """
-    # TODO: use host/path/headers/param shapes
-    return "unknown", "unknown", ()
+
+    parts = []
+    for part in text.split('.'):
+        match = re.match(r"(\d+)", part)
+        if match:
+            parts.append(int(match.group(1)))
+        else:
+            break
+    return tuple(parts)
+
+
+def fingerprint(event: Dict[str, Any]) -> Tuple[str, str, Tuple[int, ...]]:
+    """Infer ``(platform, sdk, version)`` from a normalized event.
+
+    The implementation is intentionally heuristic: it inspects headers commonly
+    found in telemetry events.  If a field is missing the corresponding value
+    defaults to ``"unknown"`` or an empty version tuple.
+    """
+
+    headers = event.get("headers", {})
+    ua = headers.get("User-Agent", "").lower()
+
+    if "roku" in ua:
+        platform = "roku"
+    elif "android" in ua:
+        platform = "android"
+    elif "ios" in ua or "iphone" in ua:
+        platform = "ios"
+    else:
+        platform = "unknown"
+
+    sdk = event.get("sdk") or headers.get("X-SDK-Name", "unknown")
+
+    version_str = event.get("sdk_version") or headers.get("X-SDK-Version", "")
+    version = _parse_version(version_str)
+
+    return platform, sdk, version

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from goblean.fingerprint import fingerprint
+
+
+def test_fingerprint_heuristics():
+    event = {
+        "headers": {
+            "User-Agent": "Roku/DVP-9.10", 
+            "X-SDK-Name": "hb-api", 
+            "X-SDK-Version": "3.6.0"
+        }
+    }
+    assert fingerprint(event) == ("roku", "hb-api", (3, 6, 0))
+
+
+def test_fingerprint_missing_fields():
+    event = {}
+    assert fingerprint(event) == ("unknown", "unknown", ())


### PR DESCRIPTION
## Summary
- implement simple heuristic to infer platform, SDK and version from telemetry event headers
- add tests covering fingerprinting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd3801cc748323919f1bbaced93682