### PR TITLE
Track parameter stability in dictionary

### DIFF
--- a/goblean/dictionary/__init__.py
+++ b/goblean/dictionary/__init__.py
@@ -13,6 +13,32 @@ def new_dictionary() -> Dict[str, Any]:
     return defaultdict(dict)
 
 
+def update_dictionary(
+    dictionary: Dict[str, Dict[str, Any]],
+    params: Dict[str, Any],
+) -> None:
+    """Update *dictionary* statistics with observed *params*.
+
+    Each parameter tracks how many times it has been seen along with a simple
+    stability metric: the frequency of the most common value divided by the
+    total observations.  This allows callers to identify parameters that appear
+    consistently across sessions.
+    """
+
+    for name, value in params.items():
+        meta = dictionary[name]
+
+        # Increment total observations.
+        meta["seen"] = meta.get("seen", 0) + 1
+
+        # Track how often each value has been seen.
+        value_counts: Dict[Any, int] = meta.setdefault("value_counts", {})
+        value_counts[value] = value_counts.get(value, 0) + 1
+
+        # Update stability as the dominant value frequency over total seen.
+        meta["stability"] = max(value_counts.values()) / meta["seen"]
+
+
 def unknown_stable_params(
     dictionary: Dict[str, Dict[str, Any]],
     known_set: Set[str],

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -6,7 +6,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import goblean.dictionary as d
 
 
-def test_unknown_stable_params_filters_correctly():
+def test_unknown_stable_params_filters_correctly() -> None:
     dictionary = {
         "param1": {"seen": 1000, "stability": 0.95},
         "param2": {"seen": 400, "stability": 0.97},  # too few sessions
@@ -17,3 +17,14 @@ def test_unknown_stable_params_filters_correctly():
 
     result = d.unknown_stable_params(dictionary, known)
     assert result == ["param1"]
+
+
+def test_update_dictionary_tracks_seen_and_stability() -> None:
+    dictionary = d.new_dictionary()
+
+    d.update_dictionary(dictionary, {"foo": "a"})
+    d.update_dictionary(dictionary, {"foo": "a"})
+    d.update_dictionary(dictionary, {"foo": "b"})
+
+    assert dictionary["foo"]["seen"] == 3
+    assert dictionary["foo"]["stability"] == 2 / 3


### PR DESCRIPTION
## Summary
- track parameter frequency and stability in the dictionary
- unit test for dictionary updates and stability calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5582d48c8323adb55b50c99e3906