### PR TITLE
feat: add dictionary persistence

### DIFF
--- a/goblean/dictionary/__init__.py
+++ b/goblean/dictionary/__init__.py
@@ -1,6 +1,8 @@
 """Dictionary of telemetry parameters."""
 
 from collections import defaultdict
+import json
+from pathlib import Path
 from typing import Dict, Any, Set, List
 
 
@@ -70,3 +72,18 @@ def unknown_stable_params(
             continue
         results.append(param)
     return results
+
+
+def save_dictionary(dictionary: Dict[str, Any], path: Path) -> None:
+    """Serialize *dictionary* to *path* as JSON."""
+
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(dictionary, f)
+
+
+def load_dictionary(path: Path) -> Dict[str, Any]:
+    """Load a dictionary previously saved with :func:`save_dictionary`."""
+
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return defaultdict(dict, data)

--- a/tests/test_dictionary.py
+++ b/tests/test_dictionary.py
@@ -28,3 +28,20 @@ def test_update_dictionary_tracks_seen_and_stability() -> None:
 
     assert dictionary["foo"]["seen"] == 3
     assert dictionary["foo"]["stability"] == 2 / 3
+
+
+def test_dictionary_roundtrip(tmp_path: Path) -> None:
+    dictionary = d.new_dictionary()
+    d.update_dictionary(dictionary, {"foo": "bar"})
+
+    path = tmp_path / "dict.json"
+    d.save_dictionary(dictionary, path)
+
+    loaded = d.load_dictionary(path)
+    assert loaded == {
+        "foo": {
+            "seen": 1,
+            "value_counts": {"bar": 1},
+            "stability": 1.0,
+        }
+    }


### PR DESCRIPTION
## Summary
- add save/load helpers for telemetry dictionaries
- test dictionary serialization roundtrip

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5e352c4083239eaaaaa05c02b685