### PR TITLE
feat: add HAR canonical envelope helper

### DIFF
--- a/goblean/normalize/envelope.py
+++ b/goblean/normalize/envelope.py
@@ -3,14 +3,55 @@
 Functions here convert raw platform telemetry into a shared
 schema that downstream modules can operate on.
 """
+
 from __future__ import annotations
+
 from typing import Any, Dict
 
 
-def canonical_envelope(raw_event: Dict[str, Any]) -> Dict[str, Any]:
-    """Return a minimal canonical representation of *raw_event*.
+def _list_to_dict(items: Any) -> Dict[str, Any]:
+    """Convert a list of ``{"name": .., "value": ..}`` pairs to a dict.
 
-    This placeholder simply echoes the input; normalization logic
-    will map platform-specific fields into a shared schema.
+    The helper is tolerant of slightly malformed inputs: entries lacking the
+    expected keys are ignored rather than raising errors.  Non-list inputs
+    produce an empty dictionary.
     """
-    return dict(raw_event)
+
+    if not isinstance(items, list):
+        return {}
+    result: Dict[str, Any] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        value = item.get("value")
+        if name is not None and value is not None:
+            result[name] = value
+    return result
+
+
+def canonical_envelope(raw_event: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a minimal canonical representation of ``raw_event``.
+
+    The function expects a structure resembling a HAR request entry.  It pulls
+    out common fields (``url``, ``method``, headers and query parameters) into a
+    simplified dictionary so downstream modules can operate on a consistent
+    schema regardless of the original telemetry source.
+    """
+
+    request = raw_event.get("request", {}) if isinstance(raw_event, dict) else {}
+    envelope: Dict[str, Any] = {
+        "url": request.get("url"),
+        "method": request.get("method"),
+        "headers": _list_to_dict(request.get("headers", [])),
+        "params": _list_to_dict(request.get("queryString", [])),
+    }
+
+    post = request.get("postData")
+    if isinstance(post, dict):
+        text = post.get("text")
+        if text is not None:
+            envelope["body"] = text
+
+    return envelope
+

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from goblean.normalize import canonical_envelope
+
+
+def test_canonical_envelope_extracts_fields() -> None:
+    raw = {
+        "request": {
+            "url": "https://example.com/api",
+            "method": "GET",
+            "headers": [
+                {"name": "User-Agent", "value": "TestAgent"},
+                {"name": "X-Foo", "value": "bar"},
+            ],
+            "queryString": [
+                {"name": "a", "value": "1"},
+                {"name": "b", "value": "2"},
+            ],
+            "postData": {"text": "body"},
+        }
+    }
+
+    env = canonical_envelope(raw)
+    assert env["url"] == "https://example.com/api"
+    assert env["method"] == "GET"
+    assert env["headers"] == {"User-Agent": "TestAgent", "X-Foo": "bar"}
+    assert env["params"] == {"a": "1", "b": "2"}
+    assert env["body"] == "body"
+
+
+def test_canonical_envelope_handles_missing() -> None:
+    """Missing sections should result in empty mappings, not errors."""
+
+    env = canonical_envelope({})
+    assert env == {"url": None, "method": None, "headers": {}, "params": {}}
+


### PR DESCRIPTION
## Summary
- implement `canonical_envelope` to normalize HAR request entries into a consistent schema
- add tests covering field extraction and graceful handling of missing data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5efeeb0483239fea0daf9c0a24ea