### PR TITLE
Handle case-insensitive headers in fingerprinting

### DIFF
--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -20,3 +20,15 @@ def test_fingerprint_heuristics():
 def test_fingerprint_missing_fields():
     event = {}
     assert fingerprint(event) == ("unknown", "unknown", ())
+
+
+def test_fingerprint_header_case_insensitive():
+    """Header keys should be matched regardless of case."""
+    event = {
+        "headers": {
+            "user-agent": "Android/10",
+            "x-sdk-name": "hb-api",
+            "x-sdk-version": "1.2.3",
+        }
+    }
+    assert fingerprint(event) == ("android", "hb-api", (1, 2, 3))


### PR DESCRIPTION
## Summary
- Normalize header names when inferring platform and SDK version to allow case-insensitive matching
- Test fingerprinting with lowercase header names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd5fed0a808323a0846ef1a88e0a5f