### PR TITLE
Parse form-encoded POST bodies

### DIFF
--- a/goblean/normalize/envelope.py
+++ b/goblean/normalize/envelope.py
@@ -67,6 +67,12 @@ def canonical_envelope(raw_event: Dict[str, Any]) -> Dict[str, Any]:
         text = post.get("text")
         if text is not None:
             envelope["body"] = text
+        mime = post.get("mimeType", "")
+        if mime.startswith("application/x-www-form-urlencoded"):
+            # Parse form-encoded body into a separate mapping so callers can
+            # access structured parameters submitted via POST requests.  Blank
+            # values are preserved to mirror the behaviour of browsers.
+            envelope["form"] = dict(parse_qsl(text or "", keep_blank_values=True))
 
     return envelope
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -46,3 +46,20 @@ def test_canonical_envelope_handles_missing() -> None:
     env = canonical_envelope({})
     assert env == {"url": None, "method": None, "headers": {}, "params": {}}
 
+
+def test_canonical_envelope_parses_form_body() -> None:
+    """Form-encoded POST bodies should be exposed as structured parameters."""
+
+    raw = {
+        "request": {
+            "url": "https://example.com/api",
+            "postData": {
+                "mimeType": "application/x-www-form-urlencoded",
+                "text": "a=1&b=2",
+            },
+        }
+    }
+
+    env = canonical_envelope(raw)
+    assert env["form"] == {"a": "1", "b": "2"}
+


### PR DESCRIPTION
## Summary
- parse application/x-www-form-urlencoded bodies into structured `form` mapping in the canonical event envelope
- add unit test covering form body extraction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd61b3a4dc83238ae817826cbd7b86