### PR TITLE
feat: add normalize CLI and progress ledger

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -1,0 +1,9 @@
+- ts: 2025-09-07T11:18:06Z
+  step: "Normalize CLI writes canonical jsonl"
+  evidence:
+    coverage_before: 0.00
+    coverage_after: 0.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: []
+  next_hint: "Add schema checker for Canonical Event Envelope; rollback: remove normalize CLI and test"

--- a/goblean/normalize/__main__.py
+++ b/goblean/normalize/__main__.py
@@ -1,0 +1,40 @@
+"""CLI for converting HAR entries to canonical JSONL."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+from .envelope import canonical_envelope
+
+
+def normalize_entries(har: Dict[str, Any]) -> Iterable[Dict[str, Any]]:
+    """Yield canonical envelopes for each entry in *har*.
+
+    The function expects a mapping parsed from a HAR file.
+    """
+    entries = har.get("log", {}).get("entries", [])
+    for entry in entries:
+        yield canonical_envelope(entry)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Write canonical JSONL from HAR file."
+    )
+    parser.add_argument("har", type=Path, help="Input .har file")
+    parser.add_argument("out", type=Path, help="Output .jsonl path")
+    args = parser.parse_args()
+
+    with args.har.open("r", encoding="utf-8") as f:
+        har = json.load(f)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as out_f:
+        for env in normalize_entries(har):
+            out_f.write(json.dumps(env) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_normalize_cli.py
+++ b/tests/test_normalize_cli.py
@@ -1,0 +1,28 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_normalize_cli_writes_jsonl(tmp_path: Path) -> None:
+    har_data = {
+        "log": {
+            "entries": [
+                {"request": {"url": "https://example.com", "method": "GET"}}
+            ]
+        }
+    }
+    har_path = tmp_path / "sample.har"
+    har_path.write_text(json.dumps(har_data))
+    out_path = tmp_path / "out.jsonl"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "goblean.normalize", str(har_path), str(out_path)],
+        check=True,
+    )
+    assert result.returncode == 0
+    lines = out_path.read_text().splitlines()
+    assert lines
+    env = json.loads(lines[0])
+    assert env["url"] == "https://example.com"
+    assert env["method"] == "GET"


### PR DESCRIPTION
## Summary
- add CLI entrypoint for normalization converting HAR files to canonical JSON lines
- document progress with ledger entry
- test CLI writes canonical JSONL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd696ee4c08323a821a18398f88861