### PR TITLE
Add canonical envelope schema checker

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -7,3 +7,12 @@
     fp_rate_after: 0.00
     artifacts: []
   next_hint: "Add schema checker for Canonical Event Envelope; rollback: remove normalize CLI and test"
+- ts: 2025-09-07T11:23:20Z
+  step: "Schema checker validates canonical envelopes"
+  evidence:
+    coverage_before: 0.00
+    coverage_after: 0.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: []
+  next_hint: "Integrate hb_re or implement goblin.report for cadence; rollback: remove schema checker and test"

--- a/goblean/schema_check.py
+++ b/goblean/schema_check.py
@@ -1,0 +1,49 @@
+"""Validate canonical envelopes against a simple schema."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel
+
+
+class CanonicalEnvelope(BaseModel):
+    url: Optional[str] = None
+    method: Optional[str] = None
+    headers: Dict[str, Any]
+    params: Dict[str, Any]
+    body: Optional[str] = None
+    form: Optional[Dict[str, str]] = None
+    json: Any | None = None
+
+
+def validate_envelope(envelope: Dict[str, Any]) -> CanonicalEnvelope:
+    """Return a validated ``CanonicalEnvelope`` instance."""
+    return CanonicalEnvelope.model_validate(envelope)
+
+
+def validate_file(path: Path) -> int:
+    """Validate each line of *path* and return the number of envelopes."""
+    count = 0
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            validate_envelope(json.loads(line))
+            count += 1
+    return count
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate canonical JSONL file")
+    parser.add_argument("path", type=Path, help="Input canonical jsonl")
+    args = parser.parse_args()
+
+    count = validate_file(args.path)
+    print(f"Validated {count} envelopes")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/tests/test_schema_check.py
+++ b/tests/test_schema_check.py
@@ -1,0 +1,29 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_schema_check_accepts_valid_envelope(tmp_path: Path) -> None:
+    env = {"url": "https://example.com", "method": "GET", "headers": {}, "params": {}}
+    path = tmp_path / "env.jsonl"
+    path.write_text(json.dumps(env) + "\n")
+    result = subprocess.run(
+        [sys.executable, "-m", "goblean.schema_check", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "Validated 1 envelopes" in result.stdout
+
+
+def test_schema_check_rejects_invalid_envelope(tmp_path: Path) -> None:
+    env = {"url": "https://example.com"}
+    path = tmp_path / "env.jsonl"
+    path.write_text(json.dumps(env) + "\n")
+    result = subprocess.run(
+        [sys.executable, "-m", "goblean.schema_check", str(path)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- introduce `schema_check` CLI using Pydantic to validate canonical envelopes
- test valid and invalid JSONL envelopes via the CLI
- record progress with next steps toward cadence reporting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd6aba65f4832383b04fd1665c52a8