### PR TITLE
Add basic report metrics

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -16,3 +16,12 @@
     fp_rate_after: 0.00
     artifacts: []
   next_hint: "Integrate hb_re or implement goblin.report for cadence; rollback: remove schema checker and test"
+- ts: 2025-09-07T11:33:58Z
+  step: "Basic report computes cadence and playhead monotonicity"
+  evidence:
+    coverage_before: 0.00
+    coverage_after: 0.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: []
+  next_hint: "Emit baseline CSVs from report; rollback: remove goblin.report and tests"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -1,0 +1,67 @@
+"""Basic metrics derived from canonical envelopes."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def metrics_from_canonical(path: Path) -> Dict[str, Any]:
+    """Compute simple metrics from a canonical JSONL file.
+
+    The function returns a mapping with event ``count``, average ``cadence`` in
+    the timestamp sequence (seconds between events), and a boolean flag
+    ``non_decreasing_playhead`` indicating whether the ``playhead`` parameter is
+    monotonic.
+    """
+
+    count = 0
+    ts_list: list[float] = []
+    playheads: list[float] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            if not line.strip():
+                continue
+            env = json.loads(line)
+            count += 1
+            params = env.get("params", {})
+            ts = params.get("ts")
+            if ts is not None:
+                try:
+                    ts_list.append(float(ts))
+                except (TypeError, ValueError):
+                    pass
+            ph = params.get("playhead")
+            if ph is not None:
+                try:
+                    playheads.append(float(ph))
+                except (TypeError, ValueError):
+                    pass
+    cadence = 0.0
+    if len(ts_list) > 1:
+        cadence = (ts_list[-1] - ts_list[0]) / (len(ts_list) - 1)
+    non_decreasing_playhead = (
+        all(later >= earlier for earlier, later in zip(playheads, playheads[1:]))
+        if playheads
+        else True
+    )
+    return {
+        "count": count,
+        "cadence": cadence,
+        "non_decreasing_playhead": non_decreasing_playhead,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute basic metrics from canonical JSONL"
+    )
+    parser.add_argument("path", type=Path, help="Input canonical jsonl")
+    args = parser.parse_args()
+    metrics = metrics_from_canonical(args.path)
+    print(json.dumps(metrics))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,20 @@
+import json
+from pathlib import Path
+
+from goblean.report import metrics_from_canonical
+
+
+def test_metrics_from_canonical(tmp_path: Path) -> None:
+    data = [
+        {"params": {"ts": 0, "playhead": 0}},
+        {"params": {"ts": 1, "playhead": 1}},
+        {"params": {"ts": 2, "playhead": 2}},
+    ]
+    path = tmp_path / "canonical.jsonl"
+    with path.open("w", encoding="utf-8") as f:
+        for env in data:
+            f.write(json.dumps(env) + "\n")
+    metrics = metrics_from_canonical(path)
+    assert metrics["count"] == 3
+    assert metrics["cadence"] == 1.0
+    assert metrics["non_decreasing_playhead"] is True


### PR DESCRIPTION
## Summary
- implement `goblean.report` to compute event count, cadence, and playhead monotonicity
- cover metrics with unit test
- record progress for new report module

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd6d5970ec83239b6e59f947bbae02