### PR TITLE
Add baseline CSV emission for reports

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -25,3 +25,12 @@
     fp_rate_after: 0.00
     artifacts: []
   next_hint: "Emit baseline CSVs from report; rollback: remove goblin.report and tests"
+- ts: 2025-09-07T11:40:28Z
+  step: "Baseline CSVs emitted for observability"
+  evidence:
+    coverage_before: 0.00
+    coverage_after: 0.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/metrics_daily.csv","out/violations.csv","out/coverage.csv","out/dictionary.csv","out/rules_index.csv","out/clusters.csv","out/sessions_index.csv"]
+  next_hint: "Add first spec and golden test; rollback: remove CSV emission and related tests"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import argparse
+import csv
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict
 
@@ -46,11 +48,44 @@ def metrics_from_canonical(path: Path) -> Dict[str, Any]:
         if playheads
         else True
     )
+    first_ts = ts_list[0] if ts_list else None
     return {
         "count": count,
         "cadence": cadence,
         "non_decreasing_playhead": non_decreasing_playhead,
+        "first_ts": first_ts,
     }
+
+
+def write_baseline_csvs(canonical: Path, out_dir: Path) -> None:
+    """Write baseline observability CSVs to *out_dir*.
+
+    Only ``metrics_daily.csv`` receives a data row; the rest contain headers
+    only so future steps can append to them.
+    """
+
+    metrics = metrics_from_canonical(canonical)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    header = ["date","platform","sdk","version_scope","batch","coverage","fp_rate","tp_rate","fn_rate","violations","total_sessions","notes"]
+    date_str = ""
+    if metrics.get("first_ts") is not None:
+        date_str = datetime.fromtimestamp(float(metrics["first_ts"]), tz=timezone.utc).date().isoformat()
+    row = [date_str,"unknown","unknown","unknown","0",0.0,0.0,0.0,0.0,0,1,""]
+    with (out_dir / "metrics_daily.csv").open("w", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerows([header,row])
+
+    other_files: Dict[str, list[str]] = {
+        "violations.csv": ["session_id","event_id","platform","sdk","version_guess","rule_id","fail_code","severity","ts"],
+        "coverage.csv": ["session_id","platform","sdk","version_guess","label","confidence","source_lf_ids"],
+        "dictionary.csv": ["param","aliases","type","unit","min","max","mean","stdev","stability","presence_map","evidence_examples"],
+        "rules_index.csv": ["rule_id","scope_platforms","scope_sdks","version_range","enabled","constitutional_touch","tests_pass","tests_fail","citations","updated_at"],
+        "clusters.csv": ["cluster_id","platform_guess","sdk_guess","signature","representative_sessions","n","novelty_score"],
+        "sessions_index.csv": ["session_id","platform","sdk","version_guess","first_ts","last_ts","event_count","file_source"],
+    }
+    for name, head in other_files.items():
+        with (out_dir / name).open("w", newline="", encoding="utf-8") as f:
+            csv.writer(f).writerow(head)
 
 
 def main() -> None:
@@ -58,8 +93,11 @@ def main() -> None:
         description="Compute basic metrics from canonical JSONL"
     )
     parser.add_argument("path", type=Path, help="Input canonical jsonl")
+    parser.add_argument("--out", type=Path, help="Output directory for baseline CSVs", default=None)
     args = parser.parse_args()
     metrics = metrics_from_canonical(args.path)
+    if args.out:
+        write_baseline_csvs(args.path, args.out)
     print(json.dumps(metrics))
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,8 @@
+import csv
 import json
 from pathlib import Path
 
-from goblean.report import metrics_from_canonical
+from goblean.report import metrics_from_canonical, write_baseline_csvs
 
 
 def test_metrics_from_canonical(tmp_path: Path) -> None:
@@ -18,3 +19,26 @@ def test_metrics_from_canonical(tmp_path: Path) -> None:
     assert metrics["count"] == 3
     assert metrics["cadence"] == 1.0
     assert metrics["non_decreasing_playhead"] is True
+
+
+def test_write_baseline_csvs(tmp_path: Path) -> None:
+    canonical = tmp_path / "canonical.jsonl"
+    with canonical.open("w", encoding="utf-8") as f:
+        f.write(json.dumps({"params": {"ts": 0, "playhead": 0}}) + "\n")
+    out_dir = tmp_path / "out"
+    write_baseline_csvs(canonical, out_dir)
+    metrics_path = out_dir / "metrics_daily.csv"
+    rows = list(csv.reader(metrics_path.open("r", encoding="utf-8")))
+    assert rows[0] == ["date","platform","sdk","version_scope","batch","coverage","fp_rate","tp_rate","fn_rate","violations","total_sessions","notes"]
+    assert rows[1][0] == "1970-01-01"
+    expected_headers = {
+        "violations.csv": ["session_id","event_id","platform","sdk","version_guess","rule_id","fail_code","severity","ts"],
+        "coverage.csv": ["session_id","platform","sdk","version_guess","label","confidence","source_lf_ids"],
+        "dictionary.csv": ["param","aliases","type","unit","min","max","mean","stdev","stability","presence_map","evidence_examples"],
+        "rules_index.csv": ["rule_id","scope_platforms","scope_sdks","version_range","enabled","constitutional_touch","tests_pass","tests_fail","citations","updated_at"],
+        "clusters.csv": ["cluster_id","platform_guess","sdk_guess","signature","representative_sessions","n","novelty_score"],
+        "sessions_index.csv": ["session_id","platform","sdk","version_guess","first_ts","last_ts","event_count","file_source"],
+    }
+    for name, header in expected_headers.items():
+        with (out_dir / name).open("r", encoding="utf-8") as f:
+            assert next(csv.reader(f)) == header


### PR DESCRIPTION
## Summary
- extend `metrics_from_canonical` with first timestamp
- add `write_baseline_csvs` to emit observability CSV skeletons
- document progress of CSV emission in `docs/progress.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd6ed94c8c8323a3132bca41aef79b