### PR TITLE
Add stub spec for playhead monotonicity

### DIFF
--- a/docs/agent_notes.md
+++ b/docs/agent_notes.md
@@ -1,0 +1,3 @@
+# Agent Notes
+
+- 2025-09-07: Spec stub for playhead monotonicity added. Options: add golden pass HAR or implement validator logic to enforce rule.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -34,3 +34,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/metrics_daily.csv","out/violations.csv","out/coverage.csv","out/dictionary.csv","out/rules_index.csv","out/clusters.csv","out/sessions_index.csv"]
   next_hint: "Add first spec and golden test; rollback: remove CSV emission and related tests"
+- ts: 2025-09-07T11:50:34Z
+  step: "Spec stub for playhead monotonicity"
+  evidence:
+    coverage_before: 0.00
+    coverage_after: 0.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["rules/specs/HB_PLAYHEAD_MONOTONIC_WEB.yaml"]
+  next_hint: "Add golden test for playhead monotonicity; rollback: remove spec file"

--- a/rules/specs/HB_PLAYHEAD_MONOTONIC_WEB.yaml
+++ b/rules/specs/HB_PLAYHEAD_MONOTONIC_WEB.yaml
@@ -1,0 +1,12 @@
+{
+  "rule_id": "HB_PLAYHEAD_MONOTONIC_WEB",
+  "description": "playhead must be non-decreasing when no seeks occur",
+  "scope": {
+    "platforms": ["web"],
+    "sdks": ["unknown"],
+    "version_range": ">=0.0.0"
+  },
+  "checks": [
+    {"non_decreasing_playhead": true}
+  ]
+}


### PR DESCRIPTION
## Summary
- Introduce initial YAML spec for non-decreasing playhead
- Record progress and notes for future golden test

## Testing
- `python -m json.tool rules/specs/HB_PLAYHEAD_MONOTONIC_WEB.yaml >/tmp/spec.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd70ed3cd48323b758f4930e20de32