### PR TITLE
Add golden test for playhead monotonicity rule

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -43,3 +43,12 @@
     fp_rate_after: 0.00
     artifacts: ["rules/specs/HB_PLAYHEAD_MONOTONIC_WEB.yaml"]
   next_hint: "Add golden test for playhead monotonicity; rollback: remove spec file"
+- ts: 2025-09-07T12:00:28Z
+  step: "Golden test verifies playhead monotonicity"
+  evidence:
+    coverage_before: 0.00
+    coverage_after: 0.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["rules/tests/HB_PLAYHEAD_MONOTONIC_WEB__pass__simple.har"]
+  next_hint: "Shadow eval the spec on baseline; rollback: remove golden test and spec"

--- a/rules/tests/HB_PLAYHEAD_MONOTONIC_WEB__pass__simple.har
+++ b/rules/tests/HB_PLAYHEAD_MONOTONIC_WEB__pass__simple.har
@@ -1,0 +1,9 @@
+{
+  "log": {
+    "entries": [
+      {"request": {"method": "GET", "url": "https://example.com/hb?ts=0&playhead=0"}},
+      {"request": {"method": "GET", "url": "https://example.com/hb?ts=1&playhead=1"}},
+      {"request": {"method": "GET", "url": "https://example.com/hb?ts=2&playhead=2"}}
+    ]
+  }
+}

--- a/tests/test_playhead_monotonicity_rule.py
+++ b/tests/test_playhead_monotonicity_rule.py
@@ -1,0 +1,16 @@
+import json
+from pathlib import Path
+
+from goblean.normalize.__main__ import normalize_entries
+from goblean.report import metrics_from_canonical
+
+
+def test_playhead_monotonicity_pass(tmp_path: Path) -> None:
+    har_path = Path("rules/tests/HB_PLAYHEAD_MONOTONIC_WEB__pass__simple.har")
+    har = json.loads(har_path.read_text())
+    canonical = tmp_path / "canonical.jsonl"
+    with canonical.open("w", encoding="utf-8") as out:
+        for env in normalize_entries(har):
+            out.write(json.dumps(env) + "\n")
+    metrics = metrics_from_canonical(canonical)
+    assert metrics["non_decreasing_playhead"] is True


### PR DESCRIPTION
## Summary
- add minimal HAR sample for playhead monotonicity rule
- cover non-decreasing playhead with a golden test
- record progress entry for spec golden test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd737498bc83239126fe1325d9c067