### PR TITLE
test: verify rules index pass counts

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -79,3 +79,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/rules_index.csv"]
   next_hint: "Record tests_pass counts in rules index; rollback: remove rules index population"
+- ts: 2025-09-07T17:45:36Z
+  step: "Tests pass counts recorded in rules index"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/rules_index.csv"]
+  next_hint: "Populate citations field in rules index; rollback: remove tests pass count checks"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -45,3 +45,5 @@ def test_write_baseline_csvs(tmp_path: Path) -> None:
     assert rules_rows[0] == ["rule_id","scope_platforms","scope_sdks","version_range","enabled","constitutional_touch","tests_pass","tests_fail","citations","updated_at"]
     assert rules_rows[1][0] == "HB_PLAYHEAD_MONOTONIC_WEB"
     assert rules_rows[1][3] == "0.0.0-virtual"
+    assert rules_rows[1][6] == "1"
+    assert rules_rows[1][7] == "0"


### PR DESCRIPTION
## Summary
- verify rules index CSV counts passing and failing tests
- log progress on tracking test pass counts in rules index

## Testing
- `pytest`
- `python -m goblean.normalize WAGA.har out/canonical.jsonl`
- `python -m goblean.report out/canonical.jsonl --out out`


------
https://chatgpt.com/codex/tasks/task_e_68bdc4266edc8323a5abae6d1069b88a