### PR TITLE
Populate citations field in rules index

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -88,3 +88,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/rules_index.csv"]
   next_hint: "Populate citations field in rules index; rollback: remove tests pass count checks"
+- ts: 2025-09-07T17:56:45Z
+  step: "Citations field populated in rules index"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/rules_index.csv"]
+  next_hint: "Integrate citation quotes into rules index; rollback: remove citations population"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -45,6 +45,12 @@ def populate_rules_index(out_dir: Path) -> None:
         version_range = scope.get("version_range", "")
         tests_pass = len(list(tests_dir.glob(f"{rule_id}__pass__*.har")))
         tests_fail = len(list(tests_dir.glob(f"{rule_id}__fail__*.har")))
+        citation_urls = [
+            c.get("url", "")
+            for c in spec.get("citations", [])
+            if c.get("url")
+        ]
+        citations = "|".join(citation_urls)
         updated_at = datetime.now(timezone.utc).isoformat()
         rows.append(
             [
@@ -56,7 +62,7 @@ def populate_rules_index(out_dir: Path) -> None:
                 constitutional_touch,
                 str(tests_pass),
                 str(tests_fail),
-                "",
+                citations,
                 updated_at,
             ]
         )

--- a/rules/specs/HB_PLAYHEAD_MONOTONIC_WEB.yaml
+++ b/rules/specs/HB_PLAYHEAD_MONOTONIC_WEB.yaml
@@ -8,5 +8,11 @@
   },
   "checks": [
     {"non_decreasing_playhead": true}
+  ],
+  "citations": [
+    {
+      "url": "cached://docs/playhead-monotonicity",
+      "quote": "Playhead must not decrease."
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- include citation URLs from rule specs when generating rules_index.csv
- document citation for HB_PLAYHEAD_MONOTONIC_WEB
- record progress for citations population

## Testing
- `pytest`
- `python - <<'PY'
from pathlib import Path
from goblean.report import populate_rules_index
out_dir = Path('out_test'); out_dir.mkdir(exist_ok=True)
populate_rules_index(out_dir)
print((out_dir / 'rules_index.csv').read_text())
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bdc6c4a5f08323913d6ab9103926a1