### PR TITLE
feat: record citation quotes in rules index

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -97,3 +97,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/rules_index.csv"]
   next_hint: "Integrate citation quotes into rules index; rollback: remove citations population"
+- ts: 2025-09-07T18:52:51Z
+  step: "Citation quotes integrated into rules index"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/rules_index.csv"]
+  next_hint: "Track citation provenance fields in rules index; rollback: remove citation quotes column"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -26,6 +26,7 @@ def populate_rules_index(out_dir: Path) -> None:
         "tests_pass",
         "tests_fail",
         "citations",
+        "citation_quotes",
         "updated_at",
     ]
     rows = []
@@ -51,6 +52,12 @@ def populate_rules_index(out_dir: Path) -> None:
             if c.get("url")
         ]
         citations = "|".join(citation_urls)
+        citation_quotes = [
+            c.get("quote", "")
+            for c in spec.get("citations", [])
+            if c.get("quote")
+        ]
+        citation_quotes_str = "|".join(citation_quotes)
         updated_at = datetime.now(timezone.utc).isoformat()
         rows.append(
             [
@@ -63,6 +70,7 @@ def populate_rules_index(out_dir: Path) -> None:
                 str(tests_pass),
                 str(tests_fail),
                 citations,
+                citation_quotes_str,
                 updated_at,
             ]
         )

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -42,8 +42,21 @@ def test_write_baseline_csvs(tmp_path: Path) -> None:
         with (out_dir / name).open("r", encoding="utf-8") as f:
             assert next(csv.reader(f)) == header
     rules_rows = list(csv.reader((out_dir / "rules_index.csv").open("r", encoding="utf-8")))
-    assert rules_rows[0] == ["rule_id","scope_platforms","scope_sdks","version_range","enabled","constitutional_touch","tests_pass","tests_fail","citations","updated_at"]
+    assert rules_rows[0] == [
+        "rule_id",
+        "scope_platforms",
+        "scope_sdks",
+        "version_range",
+        "enabled",
+        "constitutional_touch",
+        "tests_pass",
+        "tests_fail",
+        "citations",
+        "citation_quotes",
+        "updated_at",
+    ]
     assert rules_rows[1][0] == "HB_PLAYHEAD_MONOTONIC_WEB"
     assert rules_rows[1][3] == "0.0.0-virtual"
     assert rules_rows[1][6] == "1"
     assert rules_rows[1][7] == "0"
+    assert rules_rows[1][9] == "Playhead must not decrease."


### PR DESCRIPTION
## Summary
- record citation quote text in generated rules_index.csv
- assert citation quotes in report baseline test
- log citation quote integration in progress ledger

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdd410b6dc832395cc74fedbf73f26