### PR TITLE
feat: track citation provenance in rules index

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -106,3 +106,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/rules_index.csv"]
   next_hint: "Track citation provenance fields in rules index; rollback: remove citation quotes column"
+- ts: 2025-09-07T18:58:10Z
+  step: "Citation provenance fields tracked in rules index"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/rules_index.csv"]
+  next_hint: "Link provenance fields to doc cache updates; rollback: remove citation provenance columns"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -27,6 +27,9 @@ def populate_rules_index(out_dir: Path) -> None:
         "tests_fail",
         "citations",
         "citation_quotes",
+        "citation_source_urls",
+        "citation_first_seen",
+        "citation_last_verified",
         "updated_at",
     ]
     rows = []
@@ -58,6 +61,24 @@ def populate_rules_index(out_dir: Path) -> None:
             if c.get("quote")
         ]
         citation_quotes_str = "|".join(citation_quotes)
+        citation_source_urls = [
+            c.get("source_url", "")
+            for c in spec.get("citations", [])
+            if c.get("source_url")
+        ]
+        citation_source_urls_str = "|".join(citation_source_urls)
+        citation_first_seen = [
+            c.get("first_seen", "")
+            for c in spec.get("citations", [])
+            if c.get("first_seen")
+        ]
+        citation_first_seen_str = "|".join(citation_first_seen)
+        citation_last_verified = [
+            c.get("last_verified", "")
+            for c in spec.get("citations", [])
+            if c.get("last_verified")
+        ]
+        citation_last_verified_str = "|".join(citation_last_verified)
         updated_at = datetime.now(timezone.utc).isoformat()
         rows.append(
             [
@@ -71,6 +92,9 @@ def populate_rules_index(out_dir: Path) -> None:
                 str(tests_fail),
                 citations,
                 citation_quotes_str,
+                citation_source_urls_str,
+                citation_first_seen_str,
+                citation_last_verified_str,
                 updated_at,
             ]
         )

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -53,6 +53,9 @@ def test_write_baseline_csvs(tmp_path: Path) -> None:
         "tests_fail",
         "citations",
         "citation_quotes",
+        "citation_source_urls",
+        "citation_first_seen",
+        "citation_last_verified",
         "updated_at",
     ]
     assert rules_rows[1][0] == "HB_PLAYHEAD_MONOTONIC_WEB"
@@ -60,3 +63,6 @@ def test_write_baseline_csvs(tmp_path: Path) -> None:
     assert rules_rows[1][6] == "1"
     assert rules_rows[1][7] == "0"
     assert rules_rows[1][9] == "Playhead must not decrease."
+    assert rules_rows[1][10] == ""
+    assert rules_rows[1][11] == ""
+    assert rules_rows[1][12] == ""


### PR DESCRIPTION
## Summary
- add columns for citation provenance to rules index generator
- verify citation provenance columns via tests
- log progress for citation provenance tracking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdd5668cdc83239429078b51c286db