### PR TITLE
Verify doc cache entries

### DIFF
--- a/docs/agent_notes.md
+++ b/docs/agent_notes.md
@@ -2,3 +2,4 @@
 
 - 2025-09-07: Spec stub for playhead monotonicity added. Options: add golden pass HAR or implement validator logic to enforce rule.
 - 2025-09-07: Shadow eval on baseline: coverage 1.0, fp_rate 0.0. Options: tighten spec scope via semver or implement version fingerprinting.
+- 2025-09-07: Doc cache verification updates last_verified. Options: schedule periodic job or handle unreachable sources.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -133,3 +133,12 @@
     fp_rate_after: 0.00
     artifacts: ["docs/doc_cache.json","out/rules_index.csv"]
   next_hint: "Periodic verification of doc cache entries; rollback: remove doc cache backfill logic and tests"
+- ts: 2025-09-07T19:15:53Z
+  step: "Doc cache verification updates last_verified"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["docs/doc_cache.json"]
+  next_hint: "Schedule regular verification runs; rollback: remove verification function"


### PR DESCRIPTION
## Summary
- add `verify_doc_cache` to validate cached documentation URLs and refresh `last_verified` timestamps
- note verification step in agent notes and progress ledger

## Testing
- `python - <<'PY'
from pathlib import Path
from goblean.report import verify_doc_cache
print(verify_doc_cache(Path('/tmp/doc_cache.json')))
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdd94394248323aa91173b0185cd30