### PR TITLE
Flag unreachable doc cache entries for manual review

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -169,3 +169,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/rules_index.csv"]
   next_hint: "Flag unreachable doc cache entries for manual review; rollback: revert skipping logic"
+- ts: 2025-09-07T19:40:37Z
+  step: "Unreachable doc cache entries flagged for manual review"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/unreachable_docs.csv"]
+  next_hint: "Notify maintainers of unreachable citations; rollback: remove unreachable docs flagging"

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -200,3 +200,32 @@ def test_skip_unreachable_doc_cache_entries(tmp_path: Path) -> None:
         doc_cache_path.unlink()
     else:
         doc_cache_path.write_text(original, encoding="utf-8")
+
+
+def test_flag_unreachable_doc_cache_entries(tmp_path: Path) -> None:
+    canonical = tmp_path / "canonical.jsonl"
+    with canonical.open("w", encoding="utf-8") as f:
+        f.write(json.dumps({"params": {"ts": 0, "playhead": 0}}) + "\n")
+    doc_cache_path = Path("docs/doc_cache.json")
+    doc_cache_path.parent.mkdir(exist_ok=True)
+    original = doc_cache_path.read_text(encoding="utf-8") if doc_cache_path.exists() else None
+    with doc_cache_path.open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "cached://docs/playhead-monotonicity": {
+                    "source_url": "https://example.com/playhead-monotonicity",
+                    "first_seen": "2024-01-01T00:00:00Z",
+                    "last_verified": "2024-01-01T00:00:00Z",
+                    "reachable": False,
+                }
+            },
+            f,
+        )
+    out_dir = tmp_path / "out"
+    write_baseline_csvs(canonical, out_dir)
+    rows = list(csv.reader((out_dir / "unreachable_docs.csv").open("r", encoding="utf-8")))
+    assert rows[1][0] == "cached://docs/playhead-monotonicity"
+    if original is None:
+        doc_cache_path.unlink()
+    else:
+        doc_cache_path.write_text(original, encoding="utf-8")


### PR DESCRIPTION
## Summary
- Track unreachable citation sources when populating the rules index
- Emit `out/unreachable_docs.csv` listing citations needing manual review
- Test coverage for unreachable doc cache flagging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bddf65ae2c8323b80b63866544d66a