### PR TITLE
Notify maintainers of unreachable citations

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -178,3 +178,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/unreachable_docs.csv"]
   next_hint: "Notify maintainers of unreachable citations; rollback: remove unreachable docs flagging"
+- ts: 2025-09-07T19:45:00Z
+  step: "Notifications generated for unreachable citations"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/unreachable_notifications.csv"]
+  next_hint: "Escalate unresolved unreachable citations; rollback: remove notification function"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -193,6 +193,25 @@ def schedule_doc_cache_verification(
     return stop_event
 
 
+def notify_unreachable_docs(out_dir: Path) -> None:
+    """Write notifications for unreachable citation sources."""
+
+    src = out_dir / "unreachable_docs.csv"
+    if not src.exists():
+        return
+    with src.open("r", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    if len(rows) <= 1:
+        return
+    notify_path = out_dir / "unreachable_notifications.csv"
+    now = datetime.now(timezone.utc).isoformat()
+    with notify_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["citation_url", "notified_at"])
+        for row in rows[1:]:
+            writer.writerow([row[0], now])
+
+
 def metrics_from_canonical(path: Path) -> Dict[str, Any]:
     """Compute simple metrics from a canonical JSONL file.
 
@@ -331,6 +350,7 @@ def write_baseline_csvs(canonical: Path, out_dir: Path) -> None:
             csv.writer(f).writerow(head)
 
     populate_rules_index(out_dir)
+    notify_unreachable_docs(out_dir)
 
 
 def main() -> None:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -225,6 +225,12 @@ def test_flag_unreachable_doc_cache_entries(tmp_path: Path) -> None:
     write_baseline_csvs(canonical, out_dir)
     rows = list(csv.reader((out_dir / "unreachable_docs.csv").open("r", encoding="utf-8")))
     assert rows[1][0] == "cached://docs/playhead-monotonicity"
+    notes = list(
+        csv.reader(
+            (out_dir / "unreachable_notifications.csv").open("r", encoding="utf-8")
+        )
+    )
+    assert notes[1][0] == "cached://docs/playhead-monotonicity"
     if original is None:
         doc_cache_path.unlink()
     else:


### PR DESCRIPTION
## Summary
- add `notify_unreachable_docs` to write notification CSVs for unreachable citation sources
- extend baseline writer to invoke notifications after populating rules index
- test unreachable citation notifications and log progress

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde03dbfcc83239aa430a59f8b43f1