### PR TITLE
Summarize escalated citations in weekly report

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -196,3 +196,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/unreachable_escalations.csv"]
   next_hint: "Summarize escalated citations in weekly report; rollback: remove escalation function"
+- ts: 2025-09-07T19:54:51Z
+  step: "Weekly report summarizes escalated citations"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/weekly_report.csv"]
+  next_hint: "Include additional metrics in weekly report; rollback: remove weekly report generation"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -231,6 +231,22 @@ def escalate_unreachable_docs(out_dir: Path) -> None:
             writer.writerow([row[0], now])
 
 
+def summarize_escalations(out_dir: Path) -> None:
+    """Summarize escalated citations in a weekly report."""
+
+    escalate_path = out_dir / "unreachable_escalations.csv"
+    if not escalate_path.exists():
+        return
+    with escalate_path.open("r", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    count = len(rows) - 1 if len(rows) > 1 else 0
+    weekly_path = out_dir / "weekly_report.csv"
+    with weekly_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["metric", "value"])
+        writer.writerow(["escalated_citations", str(count)])
+
+
 def metrics_from_canonical(path: Path) -> Dict[str, Any]:
     """Compute simple metrics from a canonical JSONL file.
 
@@ -371,6 +387,7 @@ def write_baseline_csvs(canonical: Path, out_dir: Path) -> None:
     populate_rules_index(out_dir)
     notify_unreachable_docs(out_dir)
     escalate_unreachable_docs(out_dir)
+    summarize_escalations(out_dir)
 
 
 def main() -> None:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -268,3 +268,34 @@ def test_escalate_unreachable_doc_cache_entries(tmp_path: Path) -> None:
         doc_cache_path.unlink()
     else:
         doc_cache_path.write_text(original, encoding="utf-8")
+
+
+def test_summarize_escalated_citations(tmp_path: Path) -> None:
+    canonical = tmp_path / "canonical.jsonl"
+    with canonical.open("w", encoding="utf-8") as f:
+        f.write(json.dumps({"params": {"ts": 0, "playhead": 0}}) + "\n")
+    doc_cache_path = Path("docs/doc_cache.json")
+    doc_cache_path.parent.mkdir(exist_ok=True)
+    original = doc_cache_path.read_text(encoding="utf-8") if doc_cache_path.exists() else None
+    with doc_cache_path.open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "cached://docs/playhead-monotonicity": {
+                    "source_url": "https://example.com/playhead-monotonicity",
+                    "first_seen": "2024-01-01T00:00:00Z",
+                    "last_verified": "2024-01-01T00:00:00Z",
+                    "reachable": False,
+                }
+            },
+            f,
+        )
+    out_dir = tmp_path / "out"
+    write_baseline_csvs(canonical, out_dir)
+    rows = list(
+        csv.reader((out_dir / "weekly_report.csv").open("r", encoding="utf-8"))
+    )
+    assert rows[1] == ["escalated_citations", "1"]
+    if original is None:
+        doc_cache_path.unlink()
+    else:
+        doc_cache_path.write_text(original, encoding="utf-8")


### PR DESCRIPTION
## Summary
- Add `summarize_escalations` to produce a weekly report of escalated citation counts.
- Cover weekly report generation with a regression test.
- Log progress entry noting the new weekly summary capability.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bde2a5db00832381f97920e76fa871