### PR TITLE
Include notified citation count in weekly report

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -205,3 +205,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/weekly_report.csv"]
   next_hint: "Include additional metrics in weekly report; rollback: remove weekly report generation"
+- ts: 2025-09-07T20:25:48Z
+  step: "Weekly report counts notified citations"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/weekly_report.csv"]
+  next_hint: "Add trend metrics to weekly report; rollback: remove notified citations metric"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -232,19 +232,29 @@ def escalate_unreachable_docs(out_dir: Path) -> None:
 
 
 def summarize_escalations(out_dir: Path) -> None:
-    """Summarize escalated citations in a weekly report."""
+    """Summarize citation status in a weekly report."""
 
     escalate_path = out_dir / "unreachable_escalations.csv"
-    if not escalate_path.exists():
-        return
-    with escalate_path.open("r", encoding="utf-8") as f:
-        rows = list(csv.reader(f))
-    count = len(rows) - 1 if len(rows) > 1 else 0
+    notify_path = out_dir / "unreachable_notifications.csv"
+
+    escalated = 0
+    if escalate_path.exists():
+        with escalate_path.open("r", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        escalated = len(rows) - 1 if len(rows) > 1 else 0
+
+    notified = 0
+    if notify_path.exists():
+        with notify_path.open("r", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        notified = len(rows) - 1 if len(rows) > 1 else 0
+
     weekly_path = out_dir / "weekly_report.csv"
     with weekly_path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(["metric", "value"])
-        writer.writerow(["escalated_citations", str(count)])
+        writer.writerow(["escalated_citations", str(escalated)])
+        writer.writerow(["notified_citations", str(notified)])
 
 
 def metrics_from_canonical(path: Path) -> Dict[str, Any]:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -295,6 +295,7 @@ def test_summarize_escalated_citations(tmp_path: Path) -> None:
         csv.reader((out_dir / "weekly_report.csv").open("r", encoding="utf-8"))
     )
     assert rows[1] == ["escalated_citations", "1"]
+    assert rows[2] == ["notified_citations", "1"]
     if original is None:
         doc_cache_path.unlink()
     else:


### PR DESCRIPTION
## Summary
- Track both escalated and notified citation counts in weekly_report.csv
- Verify new metric with extended report test
- Log addition in progress ledger

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bde9ca21708323bdb6ce1df31db307