### PR TITLE
Add trend metrics to weekly report

### DIFF
--- a/docs/agent_notes.md
+++ b/docs/agent_notes.md
@@ -3,3 +3,4 @@
 - 2025-09-07: Spec stub for playhead monotonicity added. Options: add golden pass HAR or implement validator logic to enforce rule.
 - 2025-09-07: Shadow eval on baseline: coverage 1.0, fp_rate 0.0. Options: tighten spec scope via semver or implement version fingerprinting.
 - 2025-09-07: Doc cache verification updates last_verified. Options: schedule periodic job or handle unreachable sources.
+- 2025-09-07: Weekly report includes trend metrics. Options: incorporate additional metrics or visualize trends.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -214,3 +214,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/weekly_report.csv"]
   next_hint: "Add trend metrics to weekly report; rollback: remove notified citations metric"
+- ts: 2025-09-07T20:53:02Z
+  step: "Trend metrics added to weekly report"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/weekly_report.csv"]
+  next_hint: "Include additional metrics in weekly report; rollback: remove trend metrics"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -250,11 +250,29 @@ def summarize_escalations(out_dir: Path) -> None:
         notified = len(rows) - 1 if len(rows) > 1 else 0
 
     weekly_path = out_dir / "weekly_report.csv"
+    prev_escalated = 0
+    prev_notified = 0
+    if weekly_path.exists():
+        with weekly_path.open("r", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        for metric, value in rows[1:]:
+            if metric == "escalated_citations":
+                prev_escalated = int(value)
+            elif metric == "notified_citations":
+                prev_notified = int(value)
     with weekly_path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(["metric", "value"])
         writer.writerow(["escalated_citations", str(escalated)])
         writer.writerow(["notified_citations", str(notified)])
+        writer.writerow([
+            "escalated_citations_trend",
+            str(escalated - prev_escalated),
+        ])
+        writer.writerow([
+            "notified_citations_trend",
+            str(notified - prev_notified),
+        ])
 
 
 def metrics_from_canonical(path: Path) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- compute delta counts for escalated and notified citations
- record weekly report trend metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf03835e08323aefff69652c07b4f