### PR TITLE
Add unreachable citation metrics to weekly report

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -223,3 +223,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/weekly_report.csv"]
   next_hint: "Include additional metrics in weekly report; rollback: remove trend metrics"
+- ts: 2025-09-07T21:04:53Z
+  step: "Additional metrics included in weekly report"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/weekly_report.csv"]
+  next_hint: "Visualize trend metrics in reports; rollback: remove extra weekly metrics"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -236,6 +236,7 @@ def summarize_escalations(out_dir: Path) -> None:
 
     escalate_path = out_dir / "unreachable_escalations.csv"
     notify_path = out_dir / "unreachable_notifications.csv"
+    unreachable_path = out_dir / "unreachable_docs.csv"
 
     escalated = 0
     if escalate_path.exists():
@@ -249,9 +250,16 @@ def summarize_escalations(out_dir: Path) -> None:
             rows = list(csv.reader(f))
         notified = len(rows) - 1 if len(rows) > 1 else 0
 
+    unreachable = 0
+    if unreachable_path.exists():
+        with unreachable_path.open("r", encoding="utf-8") as f:
+            rows = list(csv.reader(f))
+        unreachable = len(rows) - 1 if len(rows) > 1 else 0
+
     weekly_path = out_dir / "weekly_report.csv"
     prev_escalated = 0
     prev_notified = 0
+    prev_unreachable = 0
     if weekly_path.exists():
         with weekly_path.open("r", encoding="utf-8") as f:
             rows = list(csv.reader(f))
@@ -260,6 +268,8 @@ def summarize_escalations(out_dir: Path) -> None:
                 prev_escalated = int(value)
             elif metric == "notified_citations":
                 prev_notified = int(value)
+            elif metric == "unreachable_citations":
+                prev_unreachable = int(value)
     with weekly_path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(["metric", "value"])
@@ -272,6 +282,11 @@ def summarize_escalations(out_dir: Path) -> None:
         writer.writerow([
             "notified_citations_trend",
             str(notified - prev_notified),
+        ])
+        writer.writerow(["unreachable_citations", str(unreachable)])
+        writer.writerow([
+            "unreachable_citations_trend",
+            str(unreachable - prev_unreachable),
         ])
 
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -296,6 +296,10 @@ def test_summarize_escalated_citations(tmp_path: Path) -> None:
     )
     assert rows[1] == ["escalated_citations", "1"]
     assert rows[2] == ["notified_citations", "1"]
+    assert rows[3] == ["escalated_citations_trend", "1"]
+    assert rows[4] == ["notified_citations_trend", "1"]
+    assert rows[5] == ["unreachable_citations", "1"]
+    assert rows[6] == ["unreachable_citations_trend", "1"]
     if original is None:
         doc_cache_path.unlink()
     else:


### PR DESCRIPTION
## Summary
- track unreachable citation counts and trends in weekly report generation
- verify weekly report includes new metrics

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdf30699e48323ac8cde73fcd61ef7