### PR TITLE
feat: visualize weekly trend metrics

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -232,3 +232,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/weekly_report.csv"]
   next_hint: "Visualize trend metrics in reports; rollback: remove extra weekly metrics"
+- ts: 2025-09-07T21:10:00Z
+  step: "Trend metrics visualized in weekly report"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/weekly_report.csv","out/weekly_report.html"]
+  next_hint: "Persist trend history for weekly report; rollback: remove trend visualization"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -270,24 +270,35 @@ def summarize_escalations(out_dir: Path) -> None:
                 prev_notified = int(value)
             elif metric == "unreachable_citations":
                 prev_unreachable = int(value)
+    trend_escalated = escalated - prev_escalated
+    trend_notified = notified - prev_notified
+    trend_unreachable = unreachable - prev_unreachable
     with weekly_path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(["metric", "value"])
         writer.writerow(["escalated_citations", str(escalated)])
         writer.writerow(["notified_citations", str(notified)])
-        writer.writerow([
-            "escalated_citations_trend",
-            str(escalated - prev_escalated),
-        ])
-        writer.writerow([
-            "notified_citations_trend",
-            str(notified - prev_notified),
-        ])
+        writer.writerow(["escalated_citations_trend", str(trend_escalated)])
+        writer.writerow(["notified_citations_trend", str(trend_notified)])
         writer.writerow(["unreachable_citations", str(unreachable)])
-        writer.writerow([
-            "unreachable_citations_trend",
-            str(unreachable - prev_unreachable),
-        ])
+        writer.writerow(["unreachable_citations_trend", str(trend_unreachable)])
+    html_path = out_dir / "weekly_report.html"
+    with html_path.open("w", encoding="utf-8") as f:
+        f.write("<html><body>\n")
+        f.write("<h1>Weekly Citation Report</h1>\n")
+        f.write("<table><tr><th>metric</th><th>value</th></tr>\n")
+        f.write(f"<tr><td>escalated_citations</td><td>{escalated}</td></tr>\n")
+        f.write(f"<tr><td>notified_citations</td><td>{notified}</td></tr>\n")
+        f.write(f"<tr><td>unreachable_citations</td><td>{unreachable}</td></tr>\n")
+        f.write("</table>\n<h2>Trends</h2>\n")
+        for name, val in [
+            ("escalated_citations_trend", trend_escalated),
+            ("notified_citations_trend", trend_notified),
+            ("unreachable_citations_trend", trend_unreachable),
+        ]:
+            bar = "█" * max(val, 0)
+            f.write(f"<div>{name}: {val:+d} {bar}</div>\n")
+        f.write("</body></html>\n")
 
 
 def metrics_from_canonical(path: Path) -> Dict[str, Any]:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -300,6 +300,8 @@ def test_summarize_escalated_citations(tmp_path: Path) -> None:
     assert rows[4] == ["notified_citations_trend", "1"]
     assert rows[5] == ["unreachable_citations", "1"]
     assert rows[6] == ["unreachable_citations_trend", "1"]
+    html = (out_dir / "weekly_report.html").read_text(encoding="utf-8")
+    assert "escalated_citations_trend: +1 █" in html
     if original is None:
         doc_cache_path.unlink()
     else:


### PR DESCRIPTION
## Summary
- render weekly_report.html with simple bar indicators for citation trends
- test coverage for new visualization
- record progress ledger entry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf80a1e0083238c11b1eff4de9233