### PR TITLE
Persist weekly report trend history

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -241,3 +241,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/weekly_report.csv","out/weekly_report.html"]
   next_hint: "Persist trend history for weekly report; rollback: remove trend visualization"
+- ts: 2025-09-07T21:28:30Z
+  step: "Trend history persisted for weekly report"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/weekly_report_history.csv"]
+  next_hint: "Analyze trend history for patterns; rollback: remove trend history persistence"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -300,6 +300,34 @@ def summarize_escalations(out_dir: Path) -> None:
             f.write(f"<div>{name}: {val:+d} {bar}</div>\n")
         f.write("</body></html>\n")
 
+    history_path = out_dir / "weekly_report_history.csv"
+    history_exists = history_path.exists()
+    with history_path.open("a", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        if not history_exists:
+            writer.writerow(
+                [
+                    "ts",
+                    "escalated_citations",
+                    "notified_citations",
+                    "escalated_citations_trend",
+                    "notified_citations_trend",
+                    "unreachable_citations",
+                    "unreachable_citations_trend",
+                ]
+            )
+        writer.writerow(
+            [
+                datetime.now(timezone.utc).isoformat(),
+                str(escalated),
+                str(notified),
+                str(trend_escalated),
+                str(trend_notified),
+                str(unreachable),
+                str(trend_unreachable),
+            ]
+        )
+
 
 def metrics_from_canonical(path: Path) -> Dict[str, Any]:
     """Compute simple metrics from a canonical JSONL file.

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -302,6 +302,21 @@ def test_summarize_escalated_citations(tmp_path: Path) -> None:
     assert rows[6] == ["unreachable_citations_trend", "1"]
     html = (out_dir / "weekly_report.html").read_text(encoding="utf-8")
     assert "escalated_citations_trend: +1 █" in html
+    history_rows = list(
+        csv.reader(
+            (out_dir / "weekly_report_history.csv").open("r", encoding="utf-8")
+        )
+    )
+    assert history_rows[0] == [
+        "ts",
+        "escalated_citations",
+        "notified_citations",
+        "escalated_citations_trend",
+        "notified_citations_trend",
+        "unreachable_citations",
+        "unreachable_citations_trend",
+    ]
+    assert history_rows[1][1:] == ["1", "1", "1", "1", "1", "1"]
     if original is None:
         doc_cache_path.unlink()
     else:


### PR DESCRIPTION
## Summary
- Append weekly report metrics and trends to `weekly_report_history.csv`
- Test ensures history file is written with expected values
- Document progress for trend-history persistence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdf8b241f483238d2f54ed8418e737