### PR TITLE
Analyze weekly report history for patterns

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -250,3 +250,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/weekly_report_history.csv"]
   next_hint: "Analyze trend history for patterns; rollback: remove trend history persistence"
+- ts: 2025-09-07T21:34:09Z
+  step: "Trend history analyzed for patterns"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/weekly_report_analysis.csv"]
+  next_hint: "Visualize trend patterns; rollback: remove trend history analysis"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -328,6 +328,31 @@ def summarize_escalations(out_dir: Path) -> None:
             ]
         )
 
+    analyze_trend_history(out_dir)
+
+
+def analyze_trend_history(out_dir: Path) -> None:
+    """Analyze weekly report history for average trend patterns."""
+
+    history_path = out_dir / "weekly_report_history.csv"
+    if not history_path.exists():
+        return
+    with history_path.open("r", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    if len(rows) <= 1:
+        return
+    es = [int(r[3]) for r in rows[1:]]
+    no = [int(r[4]) for r in rows[1:]]
+    un = [int(r[6]) for r in rows[1:]]
+    n = len(es)
+    analysis_path = out_dir / "weekly_report_analysis.csv"
+    with analysis_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["metric", "avg_trend"])
+        writer.writerow(["escalated_citations_trend_avg", f"{sum(es)/n:.2f}"])
+        writer.writerow(["notified_citations_trend_avg", f"{sum(no)/n:.2f}"])
+        writer.writerow(["unreachable_citations_trend_avg", f"{sum(un)/n:.2f}"])
+
 
 def metrics_from_canonical(path: Path) -> Dict[str, Any]:
     """Compute simple metrics from a canonical JSONL file.

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -321,3 +321,38 @@ def test_summarize_escalated_citations(tmp_path: Path) -> None:
         doc_cache_path.unlink()
     else:
         doc_cache_path.write_text(original, encoding="utf-8")
+
+
+def test_analyze_trend_history_patterns(tmp_path: Path) -> None:
+    canonical = tmp_path / "canonical.jsonl"
+    with canonical.open("w", encoding="utf-8") as f:
+        f.write(json.dumps({"params": {"ts": 0, "playhead": 0}}) + "\n")
+    doc_cache_path = Path("docs/doc_cache.json")
+    doc_cache_path.parent.mkdir(exist_ok=True)
+    original = doc_cache_path.read_text(encoding="utf-8") if doc_cache_path.exists() else None
+    with doc_cache_path.open("w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "cached://docs/playhead-monotonicity": {
+                    "source_url": "https://example.com/playhead-monotonicity",
+                    "first_seen": "2024-01-01T00:00:00Z",
+                    "last_verified": "2024-01-01T00:00:00Z",
+                    "reachable": False,
+                }
+            },
+            f,
+        )
+    out_dir = tmp_path / "out"
+    write_baseline_csvs(canonical, out_dir)
+    write_baseline_csvs(canonical, out_dir)
+    rows = list(
+        csv.reader((out_dir / "weekly_report_analysis.csv").open("r", encoding="utf-8"))
+    )
+    assert rows[0] == ["metric", "avg_trend"]
+    assert rows[1] == ["escalated_citations_trend_avg", "0.50"]
+    assert rows[2] == ["notified_citations_trend_avg", "0.50"]
+    assert rows[3] == ["unreachable_citations_trend_avg", "0.50"]
+    if original is None:
+        doc_cache_path.unlink()
+    else:
+        doc_cache_path.write_text(original, encoding="utf-8")


### PR DESCRIPTION
## Summary
- compute average citation trends from weekly report history and emit `weekly_report_analysis.csv`
- test pattern analysis of weekly report history
- record progress for trend-history analysis

## Testing
- `PYTHONPATH=. pytest tests/test_report.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf9c950f88323adc91dd215e8065c