### PR TITLE
feat: visualize weekly trend analysis

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -259,3 +259,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/weekly_report_analysis.csv"]
   next_hint: "Visualize trend patterns; rollback: remove trend history analysis"
+- ts: 2025-09-07T21:38:00Z
+  step: "Trend patterns visualized"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/weekly_report_analysis.html"]
+  next_hint: "Integrate visualization into weekly report; rollback: remove trend pattern visualization"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -345,13 +345,29 @@ def analyze_trend_history(out_dir: Path) -> None:
     no = [int(r[4]) for r in rows[1:]]
     un = [int(r[6]) for r in rows[1:]]
     n = len(es)
+    avg_es = sum(es) / n
+    avg_no = sum(no) / n
+    avg_un = sum(un) / n
+
     analysis_path = out_dir / "weekly_report_analysis.csv"
     with analysis_path.open("w", newline="", encoding="utf-8") as f:
         writer = csv.writer(f)
         writer.writerow(["metric", "avg_trend"])
-        writer.writerow(["escalated_citations_trend_avg", f"{sum(es)/n:.2f}"])
-        writer.writerow(["notified_citations_trend_avg", f"{sum(no)/n:.2f}"])
-        writer.writerow(["unreachable_citations_trend_avg", f"{sum(un)/n:.2f}"])
+        writer.writerow(["escalated_citations_trend_avg", f"{avg_es:.2f}"])
+        writer.writerow(["notified_citations_trend_avg", f"{avg_no:.2f}"])
+        writer.writerow(["unreachable_citations_trend_avg", f"{avg_un:.2f}"])
+
+    html_path = out_dir / "weekly_report_analysis.html"
+    with html_path.open("w", encoding="utf-8") as f:
+        f.write("<html><body>\n<h1>Weekly Trend Analysis</h1>\n")
+        for name, val in [
+            ("escalated_citations_trend_avg", avg_es),
+            ("notified_citations_trend_avg", avg_no),
+            ("unreachable_citations_trend_avg", avg_un),
+        ]:
+            bar = "█" * max(int(round(val)), 0)
+            f.write(f"<div>{name}: {val:.2f} {bar}</div>\n")
+        f.write("</body></html>\n")
 
 
 def metrics_from_canonical(path: Path) -> Dict[str, Any]:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -352,6 +352,8 @@ def test_analyze_trend_history_patterns(tmp_path: Path) -> None:
     assert rows[1] == ["escalated_citations_trend_avg", "0.50"]
     assert rows[2] == ["notified_citations_trend_avg", "0.50"]
     assert rows[3] == ["unreachable_citations_trend_avg", "0.50"]
+    html = (out_dir / "weekly_report_analysis.html").read_text(encoding="utf-8")
+    assert "escalated_citations_trend_avg: 0.50" in html
     if original is None:
         doc_cache_path.unlink()
     else:


### PR DESCRIPTION
## Summary
- render simple HTML bars for weekly trend averages
- test and log visualization of trend analysis
- record progress for trend pattern visualization

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be23837a40832388c9b30f9f493ed3