### PR TITLE
Embed trend analysis into weekly report

### DIFF
--- a/docs/agent_notes.md
+++ b/docs/agent_notes.md
@@ -4,3 +4,5 @@
 - 2025-09-07: Shadow eval on baseline: coverage 1.0, fp_rate 0.0. Options: tighten spec scope via semver or implement version fingerprinting.
 - 2025-09-07: Doc cache verification updates last_verified. Options: schedule periodic job or handle unreachable sources.
 - 2025-09-07: Weekly report includes trend metrics. Options: incorporate additional metrics or visualize trends.
+- 2025-09-07: Trend patterns visualized. Options: integrate visualization into weekly report or maintain separate analysis.
+- 2025-09-07: Visualization integrated into weekly report. Options: automate distribution or expand analysis.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -268,3 +268,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/weekly_report_analysis.html"]
   next_hint: "Integrate visualization into weekly report; rollback: remove trend pattern visualization"
+- ts: 2025-09-07T21:43:00Z
+  step: "Visualization integrated into weekly report"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/weekly_report.html"]
+  next_hint: "Automate distribution of integrated report; rollback: remove visualization integration"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -330,6 +330,25 @@ def summarize_escalations(out_dir: Path) -> None:
 
     analyze_trend_history(out_dir)
 
+    analysis_path = out_dir / "weekly_report_analysis.html"
+    report_path = out_dir / "weekly_report.html"
+    if analysis_path.exists() and report_path.exists():
+        analysis_html = analysis_path.read_text(encoding="utf-8")
+        start = analysis_html.find("<body>")
+        end = analysis_html.rfind("</body>")
+        if start != -1 and end != -1:
+            snippet = analysis_html[start + len("<body>") : end]
+            content = report_path.read_text(encoding="utf-8")
+            insert = content.rfind("</body>")
+            if insert != -1:
+                content = (
+                    content[:insert]
+                    + "<h2>Trend Analysis</h2>\n"
+                    + snippet
+                    + content[insert:]
+                )
+                report_path.write_text(content, encoding="utf-8")
+
 
 def analyze_trend_history(out_dir: Path) -> None:
     """Analyze weekly report history for average trend patterns."""


### PR DESCRIPTION
## Summary
- Integrate weekly trend analysis HTML into main weekly report output.
- Record progress and planning notes for visualization integration.

## Testing
- `pytest -q`
- Generated `weekly_report.html` to confirm embedded trend analysis.


------
https://chatgpt.com/codex/tasks/task_e_68be2705b5108323a86c9b29b76e8782