### PR TITLE
Record distribution delivery receipts

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -304,3 +304,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/distribution_delivery.csv"]
   next_hint: "Record delivery receipts; rollback: remove report delivery implementation"
+- ts: 2025-09-08T16:10:37Z
+  step: "Delivery receipts recorded"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/distribution_receipts.csv"]
+  next_hint: "Analyze delivery success rates; rollback: remove receipt recording"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -443,6 +443,25 @@ def deliver_scheduled_reports(out_dir: Path) -> None:
             writer.writerow([row[0], now])
 
 
+def record_delivery_receipts(out_dir: Path) -> None:
+    """Record a receipt for each delivered report."""
+
+    delivery_path = out_dir / "distribution_delivery.csv"
+    if not delivery_path.exists():
+        return
+    with delivery_path.open("r", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    if len(rows) <= 1:
+        return
+    receipts_path = out_dir / "distribution_receipts.csv"
+    now = datetime.now(timezone.utc).isoformat()
+    with receipts_path.open("w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["file_path", "receipt_at"])
+        for row in rows[1:]:
+            writer.writerow([row[0], now])
+
+
 def metrics_from_canonical(path: Path) -> Dict[str, Any]:
     """Compute simple metrics from a canonical JSONL file.
 
@@ -587,6 +606,7 @@ def write_baseline_csvs(canonical: Path, out_dir: Path) -> None:
     queue_weekly_report(out_dir)
     schedule_distribution(out_dir)
     deliver_scheduled_reports(out_dir)
+    record_delivery_receipts(out_dir)
 
 
 def main() -> None:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -393,6 +393,10 @@ def test_distribute_weekly_report(tmp_path: Path) -> None:
     rows = list(csv.reader(delivery_path.open("r", encoding="utf-8")))
     assert rows[0] == ["file_path", "delivered_at"]
     assert Path(rows[1][0]).name == "weekly_report.html"
+    receipts_path = out_dir / "distribution_receipts.csv"
+    rows = list(csv.reader(receipts_path.open("r", encoding="utf-8")))
+    assert rows[0] == ["file_path", "receipt_at"]
+    assert Path(rows[1][0]).name == "weekly_report.html"
     if original is None:
         doc_cache_path.unlink()
     else:


### PR DESCRIPTION
## Summary
- track delivery receipts for distributed weekly reports
- test distribution flow records receipts
- log progress for receipt recording

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68beff885eb883238afae6ff3f7b30b1