### PR TITLE
Integrate delivery success trends into weekly report

### DIFF
--- a/docs/agent_notes.md
+++ b/docs/agent_notes.md
@@ -7,3 +7,4 @@
 - 2025-09-07: Trend patterns visualized. Options: integrate visualization into weekly report or maintain separate analysis.
 - 2025-09-07: Visualization integrated into weekly report. Options: automate distribution or expand analysis.
 - 2025-09-08: Distribution delivery scheduled. Options: implement report delivery or remove schedule.
+- 2025-09-08: Delivery success trends embedded into weekly report. Options: annotate distribution deltas or link to success summary.

--- a/docs/progress.md
+++ b/docs/progress.md
@@ -340,3 +340,12 @@
     fp_rate_after: 0.00
     artifacts: ["out/distribution_success_trends.html"]
   next_hint: "Integrate success trends visualization into weekly report; rollback: remove success trends visualization"
+- ts: 2025-09-08T18:10:00Z
+  step: "Delivery success trends integrated into weekly report"
+  evidence:
+    coverage_before: 1.00
+    coverage_after: 1.00
+    fp_rate_before: 0.00
+    fp_rate_after: 0.00
+    artifacts: ["out/weekly_report.html","out/distribution_success_trends.html"]
+  next_hint: "Surface success trend deltas in distribution summaries; rollback: remove success trend embedding"

--- a/goblean/report.py
+++ b/goblean/report.py
@@ -350,6 +350,7 @@ def summarize_escalations(out_dir: Path) -> None:
                 report_path.write_text(content, encoding="utf-8")
 
 
+
 def analyze_trend_history(out_dir: Path) -> None:
     """Analyze weekly report history for average trend patterns."""
 
@@ -530,6 +531,33 @@ def analyze_delivery_success(out_dir: Path) -> None:
     visualize_delivery_success_trends(out_dir)
 
 
+def integrate_delivery_success_trends(out_dir: Path) -> None:
+    """Embed delivery success trend charts into the weekly report."""
+
+    report_path = out_dir / "weekly_report.html"
+    trends_path = out_dir / "distribution_success_trends.html"
+    if not (report_path.exists() and trends_path.exists()):
+        return
+    content = report_path.read_text(encoding="utf-8")
+    if "<h2>Delivery Success Trends</h2>" in content:
+        return
+    trends_html = trends_path.read_text(encoding="utf-8")
+    start = trends_html.find("<body>")
+    end = trends_html.rfind("</body>")
+    if start == -1 or end == -1:
+        return
+    snippet = trends_html[start + len("<body>") : end].strip()
+    snippet = snippet.replace("<h1>Delivery Success Trends</h1>", "").strip()
+    if not snippet:
+        return
+    insert = content.rfind("</body>")
+    if insert == -1:
+        return
+    addition = "<h2>Delivery Success Trends</h2>\n" + snippet + "\n"
+    updated = content[:insert] + addition + content[insert:]
+    report_path.write_text(updated, encoding="utf-8")
+
+
 def metrics_from_canonical(path: Path) -> Dict[str, Any]:
     """Compute simple metrics from a canonical JSONL file.
 
@@ -676,6 +704,7 @@ def write_baseline_csvs(canonical: Path, out_dir: Path) -> None:
     deliver_scheduled_reports(out_dir)
     record_delivery_receipts(out_dir)
     analyze_delivery_success(out_dir)
+    integrate_delivery_success_trends(out_dir)
 
 
 def main() -> None:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -302,6 +302,8 @@ def test_summarize_escalated_citations(tmp_path: Path) -> None:
     assert rows[6] == ["unreachable_citations_trend", "1"]
     html = (out_dir / "weekly_report.html").read_text(encoding="utf-8")
     assert "escalated_citations_trend: +1 █" in html
+    assert "<h2>Delivery Success Trends</h2>" in html
+    assert "1.00" in html
     history_rows = list(
         csv.reader(
             (out_dir / "weekly_report_history.csv").open("r", encoding="utf-8")
@@ -411,7 +413,11 @@ def test_distribute_weekly_report(tmp_path: Path) -> None:
     assert rows[1] == ["1.00"]
     trends_path = out_dir / "distribution_success_trends.html"
     assert trends_path.exists()
-    assert "Delivery Success Trends" in trends_path.read_text(encoding="utf-8")
+    trends_html = trends_path.read_text(encoding="utf-8")
+    assert "Delivery Success Trends" in trends_html
+    report_html = (out_dir / "weekly_report.html").read_text(encoding="utf-8")
+    assert "<h2>Delivery Success Trends</h2>" in report_html
+    assert "1.00" in report_html
     if original is None:
         doc_cache_path.unlink()
     else:


### PR DESCRIPTION
## Summary
- embed the delivery success trend visualization into the weekly report after generating distribution metrics
- add regression tests to ensure the report includes the success trend section and values
- document the new milestone in agent notes and progress ledger

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca089d962883239b546de22abf064a